### PR TITLE
HAW-130: Show images

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,17 +4,17 @@ changelog:
   exclude:
     labels:
       - ignore-for-release
-    authors:
-      - octocat
   categories:
-    - title: Breaking Changes 🛠
+    - title: New Features 🆕
       labels:
-        - Semver-Major
-        - breaking-change
-    - title: Exciting New Features 🎉
+        - new-feature
+    - title: Enhancements 🚀
       labels:
-        - Semver-Minor
         - enhancement
+    - title: Bugs fixed 🐞
+      labels:
+        - bug-fixed
+    - title: Notes 📝
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
## Issues relacionados
Fixes [HAW-130](https://buk.atlassian.net/browse/HAW-130)

## Descripción del problema
Al realizar una modificación en un beneficio que implique imágenes, al momento de ir a la sección "Publicar", estos cambios se ven como URLs en vez de imágenes. Esto complica visualizar qué cambio se realizó.

## Qué se hizo para resolver problema
Se agregó tags con la función `image_tag()` para visualizar tanto las imágenes como las calugas. Además un par de condicionales para renderizar cada caso.

## Screenshots
<img width="1511" alt="Captura de pantalla 2023-11-27 a la(s) 11 17 05" src="https://github.com/bukhr/hawaii/assets/148413763/733295a0-bbc4-4053-afad-ea62d1a48d6d">

## Cómo probar.
1. En "Beneficios", modificar una imagen de algún beneficio (imagen o caluga)
2. Ir a sección "Publicar" y se visualizarán las imágenes que sufrieron cambios


[HAW-130]: https://buk.atlassian.net/browse/HAW-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ